### PR TITLE
Update base images

### DIFF
--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:7.6.2
 FROM ${BUILD_FROM}
 
 ARG FLUENTBIT_VERSION=3.0.7

--- a/fluent-bit/Dockerfile
+++ b/fluent-bit/Dockerfile
@@ -1,11 +1,10 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:7.6.2
 FROM ${BUILD_FROM}
 
-ARG FLUENTBIT_VERSION=3.0.7
+ARG FLUENTBIT_VERSION=3.2.3
 
 RUN apt-get update -y && \
-    apt-get install curl gpg --no-install-recommends -y && \
-    apt-get install curl --no-install-recommends -y
+    apt-get install curl gpg --no-install-recommends -y
 
 COPY fluentbit.key /fluentbit.key
 RUN cat /fluentbit.key | gpg --dearmor > /usr/share/keyrings/fluentbit-keyring.gpg && \

--- a/fluent-bit/build.yaml
+++ b/fluent-bit/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:stable
-  amd64: ghcr.io/hassio-addons/debiab-base/amd64:stable
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:stable
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:stable
-  i386: ghcr.io/hassio-addons/debian-base/i386:stable
+  aarch64: ghcr.io/hassio-addons/base:17.0.1
+  amd64: ghcr.io/hassio-addons/base:17.0.1
+  armhf: ghcr.io/hassio-addons/base:17.0.1
+  armv7: ghcr.io/hassio-addons/base:17.0.1
+  i386: ghcr.io/hassio-addons/base:17.0.1

--- a/fluent-bit/build.yaml
+++ b/fluent-bit/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:17.0.1
-  amd64: ghcr.io/hassio-addons/base:17.0.1
-  armhf: ghcr.io/hassio-addons/base:17.0.1
-  armv7: ghcr.io/hassio-addons/base:17.0.1
-  i386: ghcr.io/hassio-addons/base:17.0.1
+  aarch64: ghcr.io/hassio-addons/debian-base:7.6.2
+  amd64: ghcr.io/hassio-addons/debian-base:7.6.2
+  armhf: ghcr.io/hassio-addons/debian-base:7.6.2
+  armv7: ghcr.io/hassio-addons/debian-base:7.6.2
+  i386: ghcr.io/hassio-addons/debian-base:7.6.2

--- a/fluent-bit/config.json
+++ b/fluent-bit/config.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-bit",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "slug": "fluent_bit",
   "description": "Fluent-Bit log shipping",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/fluent-bit/config.json
+++ b/fluent-bit/config.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-bit",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "slug": "fluent_bit",
   "description": "Fluent-Bit log shipping",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/fluent-bit/config.json
+++ b/fluent-bit/config.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-bit",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "slug": "fluent_bit",
   "description": "Fluent-Bit log shipping",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],

--- a/fluent-bit/config.json
+++ b/fluent-bit/config.json
@@ -1,6 +1,6 @@
 {
   "name": "fluent-bit",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "slug": "fluent_bit",
   "description": "Fluent-Bit log shipping",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],


### PR DESCRIPTION
## 👀 Purpose

- Currently the addon doesn't work - this PR fixes that
- Update to latest fluent-bit version

## ♻️ What's changed

- Updated `BUILD_FROM` to include a default, this means you can easily build the image locally if you want - I robbed it from addon_ssh
- Updated build urls so they don't 404
- Bump addon version after testing a few things
- Bump latest fluent-bit version
- Remove dupe curl install

## 📝 Notes

- I have my version up and running on my own setup for testing.